### PR TITLE
fix: use safer snprintf

### DIFF
--- a/src/pgwire/log.cpp
+++ b/src/pgwire/log.cpp
@@ -27,7 +27,8 @@ std::string now_rfc3339() {
     // move last 2 digits
     if (len > 1) {
         char minute[] = {buf[len - 2], buf[len - 1], '\0'};
-        sprintf(buf + len - 2, ":%s", minute);
+        // :mm\0 contains 4 chars
+        snprintf(buf + len - 2, 4, ":%s", minute);
     }
 
     // add one to account the colon (:)

--- a/src/pgwire/writer.cpp
+++ b/src/pgwire/writer.cpp
@@ -15,7 +15,7 @@ write_numeric(Buffer &buffer, FormatCode format_code, T value,
         break;
     case FormatCode::Text: {
         char buf[256];
-        auto len = sprintf(buf, format, value);
+        auto len = snprintf(buf, 256, format, value);
         buffer.put_numeric<int32_t>(len);
         buffer.put_bytes(reinterpret_cast<Byte const *>(buf), len);
         break;


### PR DESCRIPTION
This PR change the current use of `sprintf` to more safer alternative with `snprintf`